### PR TITLE
First review

### DIFF
--- a/MidReport.md
+++ b/MidReport.md
@@ -4,7 +4,7 @@
 
 ## **Introduction & Description**
 
-The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside NetBSD’s NPF (NetBSD Packet Filter).
+The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside NPF (NetBSD Packet Filter).
 NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145.
 
 We are using a 1:1 mapping for now, to implement NAT64 translation.

--- a/MidReport.md
+++ b/MidReport.md
@@ -9,7 +9,7 @@ NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embeddi
 
 We are using a 1:1 mapping for now, to implement NAT64 translation.
 Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server for e.g(Github).
-On the NPF, we will have a rule like this `map wm0 algo NAT64 IPv6-> IPv4`
+On the NPF, we will have a rule like this `map wm0 algo "nat64" IPv6 -> IPv4`
 Invariably this means we want to use IPv4 to access the public internet in order to communicate with GitHub’s IPv4 server.
 During this process, IPv6 header will be rewritten to IPv4. Part of the ip structure requires source and destination address so our new IPv4 source address will be the Host IPv4 address (which is likely to change during further improvement) and the IPv4 destination address will be gotten from GitHub’s IPv4 embedded IPv6 address i.e the IPv4 address in it’s IPv6 address gotten from the queried server.
 When the packet is returning from GitHub, it uses the IPv6 interface, so the IPv4 address part will be embedded back into its required position based on the prefix length passed by the user on the configuration. Then it will be sent to the IPv6 interface of the host machine.

--- a/MidReport.md
+++ b/MidReport.md
@@ -8,22 +8,26 @@ The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside Ne
 NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145.
 
 We are using a 1:1 mapping for now, to implement NAT64 translation.
-Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server for e.g(Github).
-On the NPF, we will have a rule like this `map wm0 algo "nat64" IPv6 -> IPv4`
-Invariably this means we want to use IPv4 to access the public internet in order to communicate with GitHub’s IPv4 server.
-During this process, IPv6 header will be rewritten to IPv4. Part of the ip structure requires source and destination address so our new IPv4 source address will be the Host IPv4 address (which is likely to change during further improvement) and the IPv4 destination address will be gotten from GitHub’s IPv4 embedded IPv6 address i.e the IPv4 address in it’s IPv6 address gotten from the queried server.
+Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server. As an example of IPv4 we will use Github (`github.com`) that does not support IPv4.
+
+In order to enable NAT64 on NPF we will have a rule like this:
+
+```
+map wm0 algo "nat64" IPv6 -> IPv4
+```
+
+Invariably this means we want to use IPv4 to access the public internet in order to communicate with GitHub's IPv4 server.
+During this process, IPv6 header will be rewritten to IPv4. Part of the IP structure requires source and destination address so our new IPv4 source address will be the Host IPv4 address (which is likely to change during further improvement) and the IPv4 destination address will be gotten from GitHub’s IPv4 embedded IPv6 address i.e the IPv4 address in it’s IPv6 address gotten from the queried server.
 When the packet is returning from GitHub, it uses the IPv6 interface, so the IPv4 address part will be embedded back into its required position based on the prefix length passed by the user on the configuration. Then it will be sent to the IPv6 interface of the host machine.
 
-So far, I’ve been focusing on the core translation path, making sure headers are rewritten correctly and transport checksums are updated. This also requires changes in the Userland and Kernel.
+So far, I’ve been focusing on the core translation path, making sure headers are rewritten correctly and transport checksums are updated. This also requires changes in the userland and kernel.
 
 ### Current Status
 
-Address Embedding & Extraction: Implemented functions that are responsible to extract IPv4 from IPv6 and embed IPv4 back into IPv6. Supports prefix lengths 32–96, with 96 as default.
-IP Header Rewrite: Added a functionality that enables rewriting of headers striping off the old ip header and creating a new header along with structures.
-
-Rule Parsing: Added keyword support in npf.conf, so users can specify NAT64 prefix length.
-
-Checksum Handling: Integrated checksum recalculation for IPv4, IPv6, and transport layers (TCP/UDP/ICMP).
+- Address Embedding and Extraction: Implemented functions that are responsible to extract IPv4 from IPv6 and embed IPv4 back into IPv6. Supports prefix lengths 32–96, with 96 as default.
+- IP Header Rewrite: Added a functionality that enables headers rewriting by striping off the old IP header and creating a new header along with structures.
+- Rule Parsing: Added keyword support in `npf.conf`, so users can specify NAT64 prefix length.
+- Checksum Handling: Integrated checksum recalculation for IPv4, IPv6, and transport layers (TCP/UDP/ICMP).
 
 ### More functionalities to be added (In the coming weeks)
 
@@ -34,30 +38,29 @@ Checksum Handling: Integrated checksum recalculation for IPv4, IPv6, and transpo
 ### Development Environment & Test Environment
 
 - Running NetBSD in a VM (on Windows host) for test implementation
-
-- Editing and building code on WSL (windows system linux).
+- Editing and building code on WSL (Windows Subsystem for Linux).
 
 ### Testing
 
-- Testing traffic with ping, nc (netcat), curl, dig.
+- Testing traffic with `ping`, `nc` (`netcat`), `curl`, `dig`.
 
-- Using tcpdump/tshark/Wireshark on NetBSD to inspect packets before/after translation.
+- Using `tcpdump`/`tshark`/Wireshark on NetBSD to inspect packets before/after translation.
 
 ### Debugging
 
-- Building kernel and userland with build shell script with Kernel debug logs
+- Building kernel and userland via `build.sh` with kernel debug logs enabled
 
-- Tracing packet flow with ktrace
+- Tracing packet flow via `ktrace`
 
 - Incremental testing/unit: Test functions one by one.
 
 ### Experience, Observation, Impressions
 
-Experience: Working deep inside NetBSD’s kernel networking stack has been challenging but rewarding. It gave me hands-on experience with mbufs, packet parsing, and kernel-level checksums.
+Experience: Working deep inside NetBSD’s kernel networking stack has been challenging but rewarding. It gave me hands-on experience with `mbuf`s, packet parsing, and kernel-level checksums.
 
 ### Observation
 
-- Testing NAT64 requires real network setups, not just unit tests, since correctness depends on seeing the actual wire-format packets.
+- Testing NAT64 also requires real network setups, not just unit tests, since correctness depends on seeing the actual wire-format packets.
 
 - Prefix length handling is subtle, user input must be validated and handled gracefully (defaulting to 96).
 
@@ -67,6 +70,6 @@ Experience: Working deep inside NetBSD’s kernel networking stack has been chal
 
 - The codebase is clean and modular, but sometimes well-documented to an extent.
 
-- NetBSD’s networking stack is solid and flexible, NPF feels lighter and more extensible.
+- NetBSD’s networking stack is solid and flexible, NPF feels light and extensible.
 
 - The build system is stable.

--- a/MidReport.md
+++ b/MidReport.md
@@ -5,7 +5,7 @@
 ## **Introduction & Description**
 
 The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside NPF (NetBSD Packet Filter).
-NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145.
+NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052 and RFC 6145.
 
 We are using a 1:1 mapping for now, to implement NAT64 translation.
 Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server. As an example of IPv4 we will use Github (`github.com`) that does not support IPv4.

--- a/MidReport.md
+++ b/MidReport.md
@@ -5,7 +5,7 @@
 ## **Introduction & Description**
 
 The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside NetBSD’s NPF (NetBSD Packet Filter).
-NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145).
+NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145.
 
 We are using a 1:1 mapping for now, to implement NAT64 translation.
 Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server for e.g(Github).

--- a/MidReport.md
+++ b/MidReport.md
@@ -7,12 +7,12 @@
 The goal of the NAT64 project is to implement IPv6-to-IPv4 translation inside NetBSD’s NPF (NetBSD Packet Filter).
 NAT64 enables IPv6-only clients to communicate with IPv4-only servers by embedding/extracting IPv4 addresses in IPv6 addresses as per RFC 6052, RFC 6145).
 
-We are using a 1:1 mapping for now, to implement nat64 translation.
-Whereby an ipv6 host will use its ipv4 address to communicate with an ipv4 only server for e.g(Github).
-On the NPF, we will have a rule like this `map wm0 algo NAT64 ipv6-> ipv4`
-Invariably this means we want to use ipv4 to access the public internet in order to communicate with github’s ipv4 server.
-During this process, ipv6 header will be rewritten to ipv4. Part of the ip structure requires source and destination address so our new ipv4 source address will be the Host ipv4 address (which is likely to change during further improvement) and the ipv4 destination address will be gotten from github’s ipv4 embedded ipv6 address i.e the ipv4 address in it’s ipv6 address gotten from the queried server.
-When the packet is returning from github, it uses the ipv6 interface, so the ipv4 address part will be embedded back into its required position based on the prefix length passed by the user on the configuration. Then it will be sent to the ipv6 interface of the host machine.
+We are using a 1:1 mapping for now, to implement NAT64 translation.
+Whereby an IPv6 host will use its IPv4 address to communicate with an IPv4 only server for e.g(Github).
+On the NPF, we will have a rule like this `map wm0 algo NAT64 IPv6-> IPv4`
+Invariably this means we want to use IPv4 to access the public internet in order to communicate with GitHub’s IPv4 server.
+During this process, IPv6 header will be rewritten to IPv4. Part of the ip structure requires source and destination address so our new IPv4 source address will be the Host IPv4 address (which is likely to change during further improvement) and the IPv4 destination address will be gotten from GitHub’s IPv4 embedded IPv6 address i.e the IPv4 address in it’s IPv6 address gotten from the queried server.
+When the packet is returning from GitHub, it uses the IPv6 interface, so the IPv4 address part will be embedded back into its required position based on the prefix length passed by the user on the configuration. Then it will be sent to the IPv6 interface of the host machine.
 
 So far, I’ve been focusing on the core translation path, making sure headers are rewritten correctly and transport checksums are updated. This also requires changes in the Userland and Kernel.
 


### PR DESCRIPTION
I have tried to provide some suggestions. I have tried to put rationale in the corresponding commit messages, please look at them (I will not copypaste them here).

I have also other possible suggestions and questions...

---

Instead of saying IPv6 and IPv4 maybe we can use an actual example too? For example using IPv4 of `github.com` and how it gets translated to IPv6 and back.

---

The rule syntax is not clear to me, i.e.:

```
map wm0 algo "nat64" IPv6 -> IPv4
```

I guess that "IPv6" is an actual IPv6 (e.g. `2001:470:a085:999::80`) while IPv4 is an actual IPv4 (e.g. `199.233.217.205`), right? That would be a subset of what in `npf.conf(5)` is `map-seg` (that is `( addr-mask | interface ) [ port-opts ]`), right?

Maybe also there, sharing an example rule using `github.com` as an example can help

---

Apart that... looks pretty good to me!
Thank you Dennis for writing it!

Please discuss/apply these changes and once we have reviewed and agreed please merge this PR and I will publish it on blog.NetBSD.org.


Thank you again!